### PR TITLE
Adding Paywall Feature with Sign-in

### DIFF
--- a/_posts/dynamic-routing.md
+++ b/_posts/dynamic-routing.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/jj.jpeg'
 ogImage:
   url: '/assets/blog/dynamic-routing/cover.jpg'
+state: Free
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/hello-world.md
+++ b/_posts/hello-world.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/tim.jpeg'
 ogImage:
   url: '/assets/blog/hello-world/cover.jpg'
+state: Premium
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/preview.md
+++ b/_posts/preview.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/joe.jpeg'
 ogImage:
   url: '/assets/blog/preview/cover.jpg'
+state: Premium
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  state: string
 }
 
 const HeroPost = ({
@@ -20,6 +21,7 @@ const HeroPost = ({
   excerpt,
   author,
   slug,
+  state,
 }: Props) => {
   return (
     <section>
@@ -35,6 +37,9 @@ const HeroPost = ({
           </h3>
           <div className="mb-4 md:mb-0 text-lg">
             <DateFormatter dateString={date} />
+            <div className='text-black font-bold border-black'>
+              <p className=''>{state}</p>
+            </div>
           </div>
         </div>
         <div>

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -21,6 +21,7 @@ const MoreStories = ({ posts }: Props) => {
             author={post.author}
             slug={post.slug}
             excerpt={post.excerpt}
+            state={post.state}
           />
         ))}
       </div>

--- a/components/post-header.tsx
+++ b/components/post-header.tsx
@@ -9,9 +9,10 @@ type Props = {
   coverImage: string
   date: string
   author: Author
+  state: string
 }
 
-const PostHeader = ({ title, coverImage, date, author }: Props) => {
+const PostHeader = ({ title, coverImage, date, author, state }: Props) => {
   return (
     <>
       <PostTitle>{title}</PostTitle>
@@ -27,6 +28,7 @@ const PostHeader = ({ title, coverImage, date, author }: Props) => {
         </div>
         <div className="mb-6 text-lg">
           <DateFormatter dateString={date} />
+          <p>{state}</p>
         </div>
       </div>
     </>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  state: string
 }
 
 const PostPreview = ({
@@ -20,6 +21,7 @@ const PostPreview = ({
   excerpt,
   author,
   slug,
+  state,
 }: Props) => {
   return (
     <div>
@@ -33,6 +35,9 @@ const PostPreview = ({
       </h3>
       <div className="text-lg mb-4">
         <DateFormatter dateString={date} />
+        <div className='text-black font-bold border-black'>
+              <p className=''>{state}</p>
+        </div>
       </div>
       <p className="text-lg leading-relaxed mb-4">{excerpt}</p>
       <Avatar name={author.name} picture={author.picture} />

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const config = {
+  matcher: ['/posts/hello-world', '/posts/preview'],
+}
+
+export function middleware(req: NextRequest) {
+  const basicAuth = req.headers.get('authorization')
+  const url = req.nextUrl
+
+  if (basicAuth) {
+    const authValue = basicAuth.split(' ')[1]
+    const [user, pwd] = atob(authValue).split(':')
+
+    if (user === 'username' && pwd === 'password') {
+      return NextResponse.next()
+    }
+  }
+  url.pathname = '/api/auth'
+
+  return NextResponse.rewrite(url)
+}

--- a/pages/api/auth.ts
+++ b/pages/api/auth.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(_: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('WWW-authenticate', 'Basic realm="Secure Area"')
+  res.statusCode = 401
+  res.end(`Auth Required.`)
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,6 +31,7 @@ const Index = ({ allPosts }: Props) => {
               author={heroPost.author}
               slug={heroPost.slug}
               excerpt={heroPost.excerpt}
+              state={heroPost.state}
             />
           )}
           {morePosts.length > 0 && <MoreStories posts={morePosts} />}
@@ -50,6 +51,7 @@ export const getStaticProps = async () => {
     'author',
     'coverImage',
     'excerpt',
+    'state',
   ])
 
   return {

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -43,6 +43,7 @@ const Post = ({ post, morePosts, preview }: Props) => {
                 coverImage={post.coverImage}
                 date={post.date}
                 author={post.author}
+                state={post.state}
               />
               <PostBody content={post.content} />
             </article>

--- a/types/post.ts
+++ b/types/post.ts
@@ -11,6 +11,7 @@ type PostType = {
     url: string
   }
   content: string
+  state: string
 }
 
 export default PostType


### PR DESCRIPTION
There were two primary changes made: Adding the variable to see if the post needed to be as a part of the paywall or not, along with the paywall itself.

1. Post is Premium or Free. I adjusted each post's markdown metadata, and demonstrated it on the home page of the website. To do so, some of the front-end components along with the type format of the Posts "database" needed to be adjusted as well.

2. Paywall. I added Next.js middleware. Generally, I used the default code from this link: [](https://vercel.com/templates/next.js/basic-auth-password). (Username: username, Password: password). The paywall links were added manually.

Happy to discuss this solution more!