### PR TITLE
WIP Premium content + login modal for static blog

### DIFF
--- a/_posts/dynamic-routing.md
+++ b/_posts/dynamic-routing.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/jj.jpeg'
 ogImage:
   url: '/assets/blog/dynamic-routing/cover.jpg'
+premium: false
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/hello-world.md
+++ b/_posts/hello-world.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/tim.jpeg'
 ogImage:
   url: '/assets/blog/hello-world/cover.jpg'
+premium: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/preview.md
+++ b/_posts/preview.md
@@ -8,6 +8,7 @@ author:
   picture: '/assets/blog/authors/joe.jpeg'
 ogImage:
   url: '/assets/blog/preview/cover.jpg'
+premium: false
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/components/login.tsx
+++ b/components/login.tsx
@@ -1,0 +1,43 @@
+import React, { useRef } from "react"
+
+const myStyle = {
+    fontSize: 100
+}
+
+export const LoginForm = () => {
+    const email = useRef("");
+    const password = useRef("");
+
+    const tryLogin = () => {
+        fetch("/login", { 
+            method: "POST", 
+            headers: {
+            'Content-Type': 'application/json'
+             }, 
+             body: JSON.stringify({ data: { email, password }})
+        })
+        .then((data) => {
+            console.log("You logged in! data: ", data)
+        })
+        .catch((err) => console.error("COULD NOT LOGIN: ", err))
+    }
+
+    return (
+    <form action="/login" method="post">
+        <label htmlFor="email">login email:</label>
+        <input type="email" id="email" name="email" />
+        <label htmlFor="password">password:</label>
+        <input type="password" id="password" name="passwordf" />
+        <button type="submit" onClick={tryLogin}>Submit</button>
+    </form>
+    )
+}
+
+export const LoginModal = () => {
+    return (
+        <>
+            <p style={myStyle}>You must login to view this article</p>
+            <LoginForm/>
+        </>
+    )
+}

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  premium: boolean
 }
 
 const PostPreview = ({
@@ -20,6 +21,7 @@ const PostPreview = ({
   excerpt,
   author,
   slug,
+  premium
 }: Props) => {
   return (
     <div>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -28,6 +28,9 @@ export function getPostBySlug(slug: string, fields: string[] = []) {
     if (field === 'content') {
       items[field] = content
     }
+    if (field === 'premium') {
+      items[field] = data[field]
+    }
 
     if (typeof data[field] !== 'undefined') {
       items[field] = data[field]

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,6 +50,7 @@ export const getStaticProps = async () => {
     'author',
     'coverImage',
     'excerpt',
+    'premium'
   ])
 
   return {

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -11,6 +11,7 @@ import Head from 'next/head'
 import { CMS_NAME } from '../../lib/constants'
 import markdownToHtml from '../../lib/markdownToHtml'
 import PostType from '../../types/post'
+import { LoginModal } from '../../components/login'
 
 type Props = {
   post: PostType
@@ -20,9 +21,14 @@ type Props = {
 
 const Post = ({ post, morePosts, preview }: Props) => {
   const router = useRouter()
+
+
+
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />
   }
+  const premium = post?.premium;
+  const fullTitle = premium ? post?.title + " <PREMIUM>" : post?.title;
   return (
     <Layout preview={preview}>
       <Container>
@@ -39,12 +45,16 @@ const Post = ({ post, morePosts, preview }: Props) => {
                 <meta property="og:image" content={post.ogImage.url} />
               </Head>
               <PostHeader
-                title={post.title}
+                title={fullTitle}
+                // title={post.title}
                 coverImage={post.coverImage}
                 date={post.date}
                 author={post.author}
               />
-              <PostBody content={post.content} />
+              {premium
+              ? (<LoginModal/>)
+              : <PostBody content={post.content} />
+              }
             </article>
           </>
         )}
@@ -70,8 +80,11 @@ export async function getStaticProps({ params }: Params) {
     'content',
     'ogImage',
     'coverImage',
+    'premium'
   ])
   const content = await markdownToHtml(post.content || '')
+
+  console.log("hello premium? ", post.premium)
 
   return {
     props: {

--- a/types/post.ts
+++ b/types/post.ts
@@ -11,6 +11,7 @@ type PostType = {
     url: string
   }
   content: string
+  premium: boolean
 }
 
 export default PostType


### PR DESCRIPTION
# summary
This PR is a skeleton for handling premium content via user logins.
## features
- new `login` component  added to provide a modal to prompt users to login for premium content with a login form.
- post slug now displays whether a blogpost is premium, including for its preview
## remaining work
- [ ] factor out the login form instead of inlining and handle correctly with useEffect
- [ ] stylings on the login form + premium content modal
- [ ] cookie storage and retrieval to prove user authentication